### PR TITLE
Riscv trunk

### DIFF
--- a/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -500,7 +500,7 @@ RISCVAsmParser::parseRegister(Register &Reg, char Prefix,
                                 const unsigned *Regs, bool IsAddress) {
   if (parseRegister(Reg))
     return MatchOperand_NoMatch;
-  if (Reg.Prefix != Prefix || Reg.Number > 15 || Regs[Reg.Number] == 0) {
+  if (Reg.Prefix != Prefix || Reg.Number > 31 || Regs[Reg.Number] == 0) {
     Error(Reg.StartLoc, "invalid register");
     return MatchOperand_ParseFail;
   }

--- a/lib/Target/RISCV/RISCVInstrFormats.td
+++ b/lib/Target/RISCV/RISCVInstrFormats.td
@@ -242,6 +242,27 @@ class InstI<string mnemonic, bits<7> op, bits<3> funct3,
   let Inst{6 - 0} = op;
 }
 
+//Ip-Type: Pseudo-Ops for Type-I; used for MV
+class InstIp<string mnemonic, bits<7> op, bits<3> funct3,
+            SDPatternOperator operator, RegisterOperand cls1, RegisterOperand cls2,
+            Immediate imm>
+  : InstRISCV<4, (outs cls1:$dst), (ins cls2:$src1, imm:$src2), 
+                mnemonic#"\t$dst, $src1", 
+                [(set cls1:$dst, (operator cls2:$src1, imm:$src2))]> {
+  field bits<32> Inst;
+
+  bits<5> RD;
+  bits<5> RS1;
+  bits<12> IMM;
+
+  let Inst{31-27} = RD;
+  let Inst{26-22} = RS1;
+  let Inst{21-17} = IMM{11-7};
+  let Inst{16-10} = IMM{6 -0};
+  let Inst{9 - 7} = funct3;
+  let Inst{6 - 0} = op;
+}
+
 //B-Type, too different to consolidate further
 class InstB<bits<7> op, bits<3> funct3, dag outs, dag ins, string asmstr, list<dag> pattern>
   : InstRISCV<4, outs, ins, asmstr, pattern> {

--- a/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/lib/Target/RISCV/RISCVInstrInfo.td
@@ -43,6 +43,10 @@ def ADDI: InstI<"addi", 0b0010011, 0b000       , add, GR32, GR32, imm32sx12>, Re
 def XORI: InstI<"xori", 0b0010011, 0b100       , xor, GR32, GR32, imm32sx12>;
 def ORI : InstI<"ori" , 0b0010011, 0b110       , or , GR32, GR32, imm32sx12>;
 def ANDI: InstI<"andi", 0b0010011, 0b111       , and, GR32, GR32, imm32sx12>;
+//Pseudo-Op for ADDI Rd, Rs1, 0x00
+def MV:   InstIp<"mv",   0b0010011, 0b000       , add, GR32, GR32, imm32sx12>, Requires<[IsRV32]>{
+  let IMM{11-6} = 0b000000; 
+}
 //TODO: enforce constraints here or up on level?
 def SLLI: InstI<"slli", 0b0010011, 0b001       , shl, GR32, GR32, imm32sx12>, Requires<[IsRV32]>{
   let IMM{11-6} = 0b000000; 

--- a/lib/Target/RISCV/RISCVInstrInfoRV64.td
+++ b/lib/Target/RISCV/RISCVInstrInfoRV64.td
@@ -70,6 +70,11 @@ def ADDI64: InstI<"addi", 0b0010011, 0b000       , add, GR64, GR64, imm64sx12>, 
 def XORI64: InstI<"xori", 0b0010011, 0b100       , xor, GR64, GR64, imm64sx12>, Requires<[IsRV64]>;
 def ORI64 : InstI<"ori" , 0b0010011, 0b110       , or , GR64, GR64, imm64sx12>, Requires<[IsRV64]>;
 def ANDI64: InstI<"andi", 0b0010011, 0b111       , and, GR64, GR64, imm64sx12>, Requires<[IsRV64]>;
+//Pseudo-Op for ADDI Rd, Rs1, 0x00
+def MV64:   InstIp<"mv",   0b0010011, 0b000       , add, GR64, GR64, imm64sx12>, Requires<[IsRV64]>{
+  let IMM{11-6} = 0b000000;
+}
+
 //TODO: check 64bit shifr constraints
 //TODO: enforce constraints here or up on level?
 def SLLI64: InstI<"slli", 0b0010011, 0b001       , shl, GR64, GR64, imm64sx12>, Requires<[IsRV64]> {

--- a/test/MC/RISCV/EXT-M/valid-rv32imafd-div-xfail.s
+++ b/test/MC/RISCV/EXT-M/valid-rv32imafd-div-xfail.s
@@ -1,0 +1,15 @@
+# Instructions that are valid
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32IMAFD | FileCheck %s
+# XFAIL: *
+
+#-- rq != {rs1|rs2}
+div	x10, x10, x8
+div	x10, x8, x10
+div	x10, x10, x10
+
+divu	x10, x10, x8
+divu	x10, x8, x10
+divu	x10, x10, x10
+#-- EOF
+

--- a/test/MC/RISCV/EXT-M/valid-rv32imafd.s
+++ b/test/MC/RISCV/EXT-M/valid-rv32imafd.s
@@ -1,0 +1,27 @@
+# Instructions that are valid
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32IMAFD | FileCheck --check-prefix=CHECK32 %s
+
+# CHECK32:	mul     x4, x2, x3              # encoding: [0x20,0xc4,0x04,0x33]
+# CHECK32:	mulh    x5, x3, x4              # encoding: [0x29,0x06,0x04,0xb3]
+# CHECK32:	mulhu   x6, x4, x5              # encoding: [0x31,0x48,0x05,0xb3]
+# CHECK32:	mulhsu  x8, x6, x7              # encodign: [0x39,0x8a,0x05,0xb3]	
+# CHECK32:	div     x9, x8, x7              # encoding: [0x49,0xd0,0x06,0x33]
+# CHECK32:	rem     x10, x8, x7             # encoding: [0x51,0xd0,0x07,0x33]
+# CHECK32:	divu    x9, x8, x7              # encoding: [0x49,0xd0,0x06,0xb3]
+# CHECK32:	remu    x10, x8, x7             # encoding: [0x51,0xd0,0x07,0xb3]
+
+#-- Multiplication
+mul	x5, x3, x4
+mulh	x6, x4, x5
+mulhu	x7, x5, x6
+mulhsu	x8, x6, x7
+
+#-- Division
+div	x10, x9, x8
+rem	x11, x9, x8
+divu	x10, x9, x8
+remu	x11, x9, x8
+
+#-- EOF
+

--- a/test/MC/RISCV/EXT-M/valid-rv64imafd-div-xfail.s
+++ b/test/MC/RISCV/EXT-M/valid-rv64imafd-div-xfail.s
@@ -1,0 +1,23 @@
+# Instructions that are valid
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IMAFD | FileCheck %s
+# XFAIL: *
+
+#-- rq != {rs1|rs2} 
+div	x10, x10, x8
+div	x10, x8, x10
+div	x10, x10, x10
+
+divu	x10, x10, x8
+divu	x10, x8, x10
+divu	x10, x10, x10
+
+divw	x10, x10, x8
+divw	x10, x8, x10
+divw	x10, x10, x10
+
+divuw	x10, x10, x8
+divuw	x10, x8, x10
+divuw	x10, x10, x10
+#-- EOF
+

--- a/test/MC/RISCV/EXT-M/valid-rv64imafd.s
+++ b/test/MC/RISCV/EXT-M/valid-rv64imafd.s
@@ -1,0 +1,42 @@
+# Instructions that are valid
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IMAFD | FileCheck --check-prefix=CHECK64 %s
+
+# CHECK64:	mul     x4, x2, x3              # encoding: [0x20,0xc4,0x04,0x33]
+# CHECK64:	mulh    x5, x3, x4              # encoding: [0x29,0x06,0x04,0xb3]
+# CHECK64:      mulhu   x6, x4, x5              # encoding: [0x31,0x48,0x05,0xb3]
+# CHECK64:	mulhsu	x8, x6, x7		# encodign: [0x39,0x8a,0x05,0xb3]
+# CHECK64:	mulw    x8, x6, x7              # encoding: [0x41,0xcc,0x04,0x3b]
+
+
+# CHECK64:	div     x9, x8, x7              # encoding: [0x49,0xd0,0x06,0x33]
+# CHECK64:	rem     x10, x8, x7             # encoding: [0x51,0xd0,0x07,0x33]
+# CHECK64:	divu    x9, x8, x7              # encoding: [0x49,0xd0,0x06,0xb3]
+# CHECK64:	remu    x10, x8, x7             # encoding: [0x51,0xd0,0x07,0xb3]
+
+# CHECK64:	divw    x9, x8, x7              # encoding: [0x49,0xd0,0x06,0x3b]
+# CHECK64:	remw    x10, x8, x7             # encoding: [0x51,0xd0,0x07,0x3b]
+# CHECK64:	divuw   x9, x8, x7              # encoding: [0x49,0xd0,0x06,0xbb]
+# CHECK64:	remuw   x10, x8, x7             # encoding: [0x51,0xd0,0x07,0xbb]
+
+#-- Multiplication
+mul	x5, x3, x4
+mulh	x6, x4, x5
+mulhu	x7, x5, x6
+mulhsu	x8, x6, x7
+mulw	x9, x7, x8
+
+#-- Division
+div     x10, x9, x8
+rem     x11, x9, x8
+divu    x10, x9, x8
+remu	x11, x9, x8
+
+divw	x10, x9, x8
+remw	x11, x9, x8
+divuw	x10, x9, x8
+remuw	x11, x9, x8
+
+
+#-- EOF
+

--- a/test/MC/RISCV/RV32I/invalid-xfail-operand.s
+++ b/test/MC/RISCV/RV32I/invalid-xfail-operand.s
@@ -1,0 +1,9 @@
+# Instructions that are expected to fail
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32I | FileCheck %s
+# XFAIL: *
+
+	add	x0, x1, x2, x3
+
+#-- EOF
+

--- a/test/MC/RISCV/RV32I/invalid-xfail-range.s
+++ b/test/MC/RISCV/RV32I/invalid-xfail-range.s
@@ -1,0 +1,9 @@
+# Instructions that are expected to fail
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32I | FileCheck %s
+# XFAIL: *
+
+	add	x5, x4, x32
+
+#-- EOF
+

--- a/test/MC/RISCV/RV32I/valid-xfail-imm-overflow.s
+++ b/test/MC/RISCV/RV32I/valid-xfail-imm-overflow.s
@@ -1,0 +1,10 @@
+# Instructions that are expected to fail
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32I | FileCheck %s
+# XFAIL: *
+
+	#-- overflow 32-immediate
+	addi x1, x0, 1200000000
+
+#-- EOF
+

--- a/test/MC/RISCV/RV32I/valid-xfail-nosymbol.s
+++ b/test/MC/RISCV/RV32I/valid-xfail-nosymbol.s
@@ -1,0 +1,10 @@
+# Instructions that are expected to fail
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32I | FileCheck %s
+# XFAIL: *
+
+	#-- branch to an unknown symbol 
+	beq     x0,x0, my_branch_target
+
+#-- EOF
+

--- a/test/MC/RISCV/RV32I/valid.s
+++ b/test/MC/RISCV/RV32I/valid.s
@@ -1,0 +1,168 @@
+# Instructions that are valid
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32I | FileCheck --check-prefix=CHECK32 %s
+
+
+# CHECK32: addi    x0, x0, 0               # encoding: [0x00,0x00,0x00,0x13]
+# CHECK32: addi    x1, x0, 0               # encoding: [0x08,0x00,0x00,0x13]
+# CHECK32: addi    x1, x0, 0               # encoding: [0x08,0x00,0x00,0x13]
+# CHECK32: addi    x2, x1, 0               # encoding: [0x10,0x40,0x00,0x13]
+# CHECK32: addi    x3, x2, 0               # encoding: [0x18,0x80,0x00,0x13]
+# CHECK32: addi    x4, x3, 0               # encoding: [0x20,0xc0,0x00,0x13]
+# CHECK32: addi    x5, x4, 0               # encoding: [0x29,0x00,0x00,0x13]
+# CHECK32: addi    x6, x5, 0               # encoding: [0x31,0x40,0x00,0x13]
+# CHECK32: addi    x7, x6, 0               # encoding: [0x39,0x80,0x00,0x13]
+# CHECK32: addi    x8, x7, 0               # encoding: [0x41,0xc0,0x00,0x13]
+# CHECK32: addi    x9, x8, 0               # encoding: [0x4a,0x00,0x00,0x13]
+# CHECK32: addi    x10, x9, 0              # encoding: [0x52,0x40,0x00,0x13]
+# CHECK32: addi    x11, x10, 0             # encoding: [0x5a,0x80,0x00,0x13]
+# CHECK32: addi    x12, x11, 0             # encoding: [0x62,0xc0,0x00,0x13]
+# CHECK32: addi    x13, x12, 0             # encoding: [0x6b,0x00,0x00,0x13]
+# CHECK32: addi    x14, x13, 0             # encoding: [0x73,0x40,0x00,0x13]
+
+# CHECK32: nop				   # encoding: [0x00,0x00,0x00,0x13]
+
+# CHECK32: addi	x2, x2, 1023               # encoding: [0x10,0x8f,0xfc,0x13]
+# CHECK32: addi	x3, x2, -1023              # encoding: [0x18,0xb0,0x04,0x13]
+
+# CHECK32: slti	x4, x3, 0                  # encoding: [0x20,0xc0,0x01,0x13]
+# CHECK32: slti	x5, x4, 1023               # encoding: [0x29,0x0f,0xfd,0x13]
+# CHECK32: sltiu x6, x0, 1                 # encoding: [0x30,0x00,0x05,0x93]
+
+
+# CHECK32: andi	x7, x6, 12                 # encoding: [0x39,0x80,0x33,0x93]
+# CHECK32: ori	x8, x7, -24                # encoding: [0x41,0xff,0xa3,0x13]
+# CHECK32: xori	x9, x8, 17                 # encoding: [0x4a,0x00,0x46,0x13]
+# CHECK32: xori	x10, x9, -1                # encoding: [0x52,0x7f,0xfe,0x13]
+
+# CHECK32: slli	x11, x9, 5                 # encoding: [0x5a,0x40,0x14,0x93]
+# CHECK32: srli	x12, x11, 31               # encoding: [0x62,0xc0,0x7e,0x93]
+# CHECK32: srai	x13, x12, 2                # encoding: [0x6b,0x01,0x0a,0x93]
+# CHECK32: lui	x14, 1048575               # encoding: [0x77,0xff,0xff,0xb7]
+
+#-- register encodings: x0-x31
+#--                     x0 == $0
+	addi	x0, x0, 0
+	addi	x1, x0, 0
+	addi	x2, x1, 0
+	addi	x3, x2, 0
+	addi	x4, x3, 0
+	addi	x5, x4, 0
+	addi	x6, x5, 0
+	addi	x7, x6, 0
+	addi	x8, x7, 0
+	addi	x9, x8, 0
+	addi	x10, x9, 0
+	addi	x11, x10, 0
+	addi	x12, x11, 0
+	addi	x13, x12, 0
+	addi	x14, x13, 0
+	addi	x15, x14, 0
+	addi	x16, x15, 0
+	addi	x17, x16, 0
+	addi	x18, x17, 0
+	addi	x19, x18, 0
+	addi	x20, x19, 0
+	addi	x21, x20, 0
+	addi	x22, x21, 0
+	addi	x23, x22, 0
+	addi	x24, x23, 0
+	addi	x25, x24, 0
+	addi	x26, x25, 0
+	addi	x27, x26, 0
+	addi	x28, x27, 0
+	addi	x29, x28, 0
+	addi	x30, x29, 0
+	addi	x31, x30, 0
+
+#-- INTEGER COMPUTATIONAL INSTRUCTIONS
+#-- Integer Register-Immediate
+	nop				#-- pseudo-op for addi x0, x0, 0
+	addi	x3, x2, 1023
+	addi	x4, x3, -1023
+	addi	x31, x0, 0
+	mv	x31, x0			#-- pseudo-op for addi x31, x0, 0
+	slti	x5, x4, 0
+	slti	x6, x5, 1023
+	sltiu	x7, x0, 1
+	seqz	x7,x0			#-- pseudo-op for sltiu x7,x0,1
+	andi	x8, x7, 12
+	ori	x9, x8, -24
+	xori	x10, x9, 17
+	xori	x11, x10, -1
+	not	x11, x10		#-- pseudo-op for xori x11, x10, -1
+	slli	x12, x10, 5	
+	srli	x13, x12, 31
+	srai	x14, x13, 2
+	lui	x15, 1048575
+	auipc	x16, 4
+
+#-- Integer Register-Register
+	add	x17, x16, x15
+	sub	x18, x17, x16
+	slt	x19, x18, x17
+	sltu	x20, x19, x18
+	and	x21, x20, x19
+	or	x22, x21, x20
+	xor	x23, x22, x21
+	sll	x24, x23, x22
+	srl	x25, x24, x23
+	sra	x26, x25, x24
+
+#-- CONTROL TRANSFER INSTRUCTIONS
+	mv 	x2, x0
+	jal	x27
+	jal	x0			#-- unconditional jump
+	jalr	x28, x27, 8	
+	beq	x28,x27, target_beq
+target_beq:
+	bne	x28,x27, target_bne
+target_bne:
+	blt	x29, x28, target_blt
+target_blt:
+	bltu	x30, x29, target_bltu	
+target_bltu:
+	bge	x31, x30, target_bge
+target_bge:
+	bgeu	x2, x31, target_bgeu
+target_bgeu:
+	nop
+
+#-- LOAD AND STORE INSTRUCTIONS	
+
+	sw x5, 0(x3)
+	sh x6, 0(x3)
+	sb x7, 0(x3)
+	sw x5, -4(x3)
+	sh x6, -4(x3)
+	sb x7, -4(x3)
+	sw x5, 4(x3)
+	sh x6, 4(x3)
+	sb x7, 4(x3)
+	lw x5, 0(x3)
+	lh x6, 0(x3)
+	lb x7, 0(x3)
+	lw x5, -4(x3)
+	lh x6, -4(x3)
+	lb x7, -4(x3)
+	lw x5, 4(x3)
+	lh x6, 4(x3)
+	lb x7, 4(x3)
+
+#-- MEMORY MODEL
+	fence
+	fence.i
+
+#-- SYSTEM INSTRUCTIONS
+	scall
+	sbreak
+	rdcycle	x5
+	rdcycleh x6
+	rdtime	x7
+	rdtimeh	x8
+	rdinstret x9 
+	rdinstreth x10 
+		
+
+#-- EOF
+

--- a/test/MC/RISCV/RV64I/invalid-rv64i-xfail.s
+++ b/test/MC/RISCV/RV64I/invalid-rv64i-xfail.s
@@ -1,0 +1,12 @@
+# Instructions that are valid
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64I | FileCheck --check-prefix=CHECK64 %s
+# XFAIL: *
+
+	rdcycleh x6
+	rdtimeh	x8
+	rdinstreth x10 
+		
+
+#-- EOF
+

--- a/test/MC/RISCV/RV64I/valid-xfail-nosymbol.s
+++ b/test/MC/RISCV/RV64I/valid-xfail-nosymbol.s
@@ -1,0 +1,10 @@
+# Instructions that are expected to fail
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64I | FileCheck %s
+# XFAIL: *
+
+	#-- branch to an unknown symbol 
+	beq     x0,x0, my_branch_target
+
+#-- EOF
+

--- a/test/MC/RISCV/RV64I/valid.s
+++ b/test/MC/RISCV/RV64I/valid.s
@@ -1,0 +1,210 @@
+# Instructions that are valid
+#
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64I | FileCheck --check-prefix=CHECK64 %s
+
+
+# CHECK64: addi    x0, x0, 0               # encoding: [0x00,0x00,0x00,0x13]
+# CHECK64: addi    x1, x0, 0               # encoding: [0x08,0x00,0x00,0x13]
+# CHECK64: addi    x1, x0, 0               # encoding: [0x08,0x00,0x00,0x13]
+# CHECK64: addi    x2, x1, 0               # encoding: [0x10,0x40,0x00,0x13]
+# CHECK64: addi    x3, x2, 0               # encoding: [0x18,0x80,0x00,0x13]
+# CHECK64: addi    x4, x3, 0               # encoding: [0x20,0xc0,0x00,0x13]
+# CHECK64: addi    x5, x4, 0               # encoding: [0x29,0x00,0x00,0x13]
+# CHECK64: addi    x6, x5, 0               # encoding: [0x31,0x40,0x00,0x13]
+# CHECK64: addi    x7, x6, 0               # encoding: [0x39,0x80,0x00,0x13]
+# CHECK64: addi    x8, x7, 0               # encoding: [0x41,0xc0,0x00,0x13]
+# CHECK64: addi    x9, x8, 0               # encoding: [0x4a,0x00,0x00,0x13]
+# CHECK64: addi    x10, x9, 0              # encoding: [0x52,0x40,0x00,0x13]
+# CHECK64: addi    x11, x10, 0             # encoding: [0x5a,0x80,0x00,0x13]
+# CHECK64: addi    x12, x11, 0             # encoding: [0x62,0xc0,0x00,0x13]
+# CHECK64: addi    x13, x12, 0             # encoding: [0x6b,0x00,0x00,0x13]
+# CHECK64: addi    x14, x13, 0             # encoding: [0x73,0x40,0x00,0x13]
+
+# CHECK64: nop				   # encoding: [0x00,0x00,0x00,0x13]
+
+# CHECK64: addi	x2, x2, 1023               # encoding: [0x10,0x8f,0xfc,0x13]
+# CHECK64: addi	x3, x2, -1023              # encoding: [0x18,0xb0,0x04,0x13]
+
+# CHECK64: slti	x4, x3, 0                  # encoding: [0x20,0xc0,0x01,0x13]
+# CHECK64: slti	x5, x4, 1023               # encoding: [0x29,0x0f,0xfd,0x13]
+# CHECK64: sltiu x6, x0, 1                 # encoding: [0x30,0x00,0x05,0x93]
+
+
+# CHECK64: andi	x7, x6, 12                 # encoding: [0x39,0x80,0x33,0x93]
+# CHECK64: ori	x8, x7, -24                # encoding: [0x41,0xff,0xa3,0x13]
+# CHECK64: xori	x9, x8, 17                 # encoding: [0x4a,0x00,0x46,0x13]
+# CHECK64: xori	x10, x9, -1                # encoding: [0x52,0x7f,0xfe,0x13]
+
+# CHECK64: slli	x11, x9, 5                 # encoding: [0x5a,0x40,0x14,0x93]
+# CHECK64: srli	x12, x11, 31               # encoding: [0x62,0xc0,0x7e,0x93]
+# CHECK64: srai	x13, x12, 2                # encoding: [0x6b,0x01,0x0a,0x93]
+# CHECK64: lui	x14, 1048575               # encoding: [0x77,0xff,0xff,0xb7]
+
+# CHECK64: addiw	x4, x3, 1023       # encoding: [0x20,0xcf,0xfc,0x1b]
+# CHECK64: addiw	x5, x6, 0          # encoding: [0x29,0x80,0x00,0x1b]
+# CHECK64: slliw	x11, x9, 32        # encoding: [0x5a,0x40,0x00,0x9b]
+# CHECK64: srliw	x12, x11, 33       # encoding: [0x62,0xc0,0x06,0x9b]
+# CHECK64: sraiw	x13, x12, 34       # encoding: [0x6b,0x02,0x8a,0x9b]
+
+# CHECK64: addw	x9, x10, x11               # encoding: [0x4a,0xd4,0x00,0x3b]
+# CHECK64: subw	x8, x7, x6                 # encoding: [0x41,0x8f,0x00,0x3b]
+# CHECK64: sllw	x3, x4, x5                 # encoding: [0x19,0x49,0x00,0xbb]
+# CHECK64: srlw	x5, x6, x7                 # encoding: [0x29,0xcc,0x02,0xbb]
+# CHECK64: sraw	x8, x9, x10                # encoding: [0x42,0x93,0x02,0xbb]
+
+#-- register encodings: x0-x31
+#--                     x0 == $0
+	addi	x0, x0, 0
+	addi	x1, x0, 0
+	addi	x2, x1, 0
+	addi	x3, x2, 0
+	addi	x4, x3, 0
+	addi	x5, x4, 0
+	addi	x6, x5, 0
+	addi	x7, x6, 0
+	addi	x8, x7, 0
+	addi	x9, x8, 0
+	addi	x10, x9, 0
+	addi	x11, x10, 0
+	addi	x12, x11, 0
+	addi	x13, x12, 0
+	addi	x14, x13, 0
+	addi	x15, x14, 0
+	addi	x16, x15, 0
+	addi	x17, x16, 0
+	addi	x18, x17, 0
+	addi	x19, x18, 0
+	addi	x20, x19, 0
+	addi	x21, x20, 0
+	addi	x22, x21, 0
+	addi	x23, x22, 0
+	addi	x24, x23, 0
+	addi	x25, x24, 0
+	addi	x26, x25, 0
+	addi	x27, x26, 0
+	addi	x28, x27, 0
+	addi	x29, x28, 0
+	addi	x30, x29, 0
+	addi	x31, x30, 0
+
+#-- INTEGER COMPUTATIONAL INSTRUCTIONS
+#-- Integer Register-Immediate
+	nop				#-- pseudo-op for addi x0, x0, 0
+	addi	x3, x2, 1023
+	addi	x4, x3, -1023
+	addi	x31, x0, 0
+	mv	x31, x0			#-- pseudo-op for addi x31, x0, 0
+	slti	x5, x4, 0
+	slti	x6, x5, 1023
+	sltiu	x7, x0, 1
+	seqz	x7,x0			#-- pseudo-op for sltiu x7,x0,1
+	andi	x8, x7, 12
+	ori	x9, x8, -24
+	xori	x10, x9, 17
+	xori	x11, x10, -1
+	not	x11, x10		#-- pseudo-op for xori x11, x10, -1
+	slli	x12, x10, 5	
+	srli	x13, x12, 31
+	srai	x14, x13, 2
+	lui	x15, 1048575
+	auipc	x16, 4
+
+#-- RV64I only
+	addiw	x5, x4, 1023
+	addiw	x6, x7, 0
+	sext.w	x6, x7			#-- pseudo-op for addiw x6, x7, 0
+	slliw	x12, x10, 32	
+	srliw	x13, x12, 33
+	sraiw	x14, x13, 34
+	
+
+#-- Integer Register-Register
+	add	x17, x16, x15
+	sub	x18, x17, x16
+	slt	x19, x18, x17
+	sltu	x20, x19, x18
+	and	x21, x20, x19
+	or	x22, x21, x20
+	xor	x23, x22, x21
+	sll	x24, x23, x22
+	srl	x25, x24, x23
+	sra	x26, x25, x24
+
+#-- RV64I only
+	addw	x10, x11, x12
+	subw	x9, x8, x7
+	sllw	x4, x5, x6
+	srlw	x6, x7, x8
+	sraw	x9, x10, x11
+	
+
+#-- CONTROL TRANSFER INSTRUCTIONS
+	mv 	x2, x0
+	jal	x27
+	jal	x0			#-- unconditional jump
+	jalr	x28, x27, 8	
+	beq	x28,x27, target_beq
+target_beq:
+	bne	x28,x27, target_bne
+target_bne:
+	blt	x29, x28, target_blt
+target_blt:
+	bltu	x30, x29, target_bltu	
+target_bltu:
+	bge	x31, x30, target_bge
+target_bge:
+	bgeu	x2, x31, target_bgeu
+target_bgeu:
+	nop
+
+#-- LOAD AND STORE INSTRUCTIONS	
+
+	sw x5, 0(x3)
+	sh x6, 0(x3)
+	sb x7, 0(x3)
+	sw x5, -4(x3)
+	sh x6, -4(x3)
+	sb x7, -4(x3)
+	sw x5, 4(x3)
+	sh x6, 4(x3)
+	sb x7, 4(x3)
+	lw x5, 0(x3)
+	lh x6, 0(x3)
+	lb x7, 0(x3)
+	lw x5, -4(x3)
+	lh x6, -4(x3)
+	lb x7, -4(x3)
+	lw x5, 4(x3)
+	lh x6, 4(x3)
+	lb x7, 4(x3)
+
+#-- RV64I only
+	ld x5, 0(x3)
+	ld x6, -4(x3)
+	ld x7, 4(x3)
+	lwu x5, 0(x3)
+	lhu x6, 0(x3)
+	lbu x7, 0(x3)
+	lwu x5, -4(x3)
+	lhu x6, -4(x3)
+	lbu x7, -4(x3)
+	lwu x5, 4(x3)
+	lhu x6, 4(x3)
+	lbu x7, 4(x3)
+
+
+#-- MEMORY MODEL
+	fence
+	fence.i
+
+#-- SYSTEM INSTRUCTIONS
+#-- *h encodings not supported in RV64I
+	scall
+	sbreak
+	rdcycle	x5
+	rdtime	x7
+	rdinstret x9 
+		
+
+#-- EOF
+

--- a/test/MC/RISCV/invalid-subtargets-xfail.s
+++ b/test/MC/RISCV/invalid-subtargets-xfail.s
@@ -1,0 +1,7 @@
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32IJ | FileCheck %s
+# XFAIL: *
+
+	addi	x0, x0, 0
+	
+#-- EOF
+

--- a/test/MC/RISCV/lit.local.cfg
+++ b/test/MC/RISCV/lit.local.cfg
@@ -1,0 +1,3 @@
+if not 'RISCV' in config.root.targets:
+    config.unsupported = True
+

--- a/test/MC/RISCV/valid-subtargets.s
+++ b/test/MC/RISCV/valid-subtargets.s
@@ -1,8 +1,7 @@
 #-- Subtarget Tests
 # RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32I | FileCheck %s
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32IMAFD | FileCheck %s
 # RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64I | FileCheck %s
-# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IA | FileCheck %s
-# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IAM | FileCheck %s
 # RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IAMFD | FileCheck %s
 
 # CHECK: addi    x0, x0, 0               # encoding: [0x00,0x00,0x00,0x13]

--- a/test/MC/RISCV/valid-subtargets.s
+++ b/test/MC/RISCV/valid-subtargets.s
@@ -1,0 +1,12 @@
+#-- Subtarget Tests
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV32I | FileCheck %s
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64I | FileCheck %s
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IA | FileCheck %s
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IAM | FileCheck %s
+# RUN: llvm-mc %s -triple=riscv-unknown-linux -show-encoding -mcpu=RV64IAMFD | FileCheck %s
+
+# CHECK: addi    x0, x0, 0               # encoding: [0x00,0x00,0x00,0x13]
+	addi	x0, x0, 0
+	
+#-- EOF
+


### PR DESCRIPTION
Basic tests for RV32I, RV64I, RV32IM, RV64IM; fixing register indexing bug, now permits indices to x31; adding pseudo-op for MV Rd, Rs1 ==> ADDI Rd, Rs1, 0x00 for RV32I and RV64I
