### PR TITLE
Fix assertion failures due to missing synthesizable branches in InsertBranchAtInst.

### DIFF
--- a/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -377,6 +377,23 @@ RISCVInstrInfo::InsertBranchAtInst(MachineBasicBlock &MBB, MachineInstr *I, Mach
       BuildMI(MBB, I, DL, get(RISCV::BGEU)).addMBB(TBB).addReg(Cond[2].getReg())
           .addReg(Cond[3].getReg());
       break;
+    //synth
+    case RISCV::CCMASK_CMP_GT:
+      BuildMI(MBB, I, DL, get(RISCV::BGT)).addMBB(TBB).addReg(Cond[2].getReg())
+          .addReg(Cond[3].getReg());
+      break;
+    case RISCV::CCMASK_CMP_LE:
+      BuildMI(MBB, I, DL, get(RISCV::BLE)).addMBB(TBB).addReg(Cond[2].getReg())
+          .addReg(Cond[3].getReg());
+      break;
+    case RISCV::CCMASK_CMP_GT | RISCV::CCMASK_CMP_UO:
+      BuildMI(MBB, I, DL, get(RISCV::BGTU)).addMBB(TBB).addReg(Cond[2].getReg())
+          .addReg(Cond[3].getReg());
+      break;
+    case RISCV::CCMASK_CMP_LE | RISCV::CCMASK_CMP_UO:
+      BuildMI(MBB, I, DL, get(RISCV::BLEU)).addMBB(TBB).addReg(Cond[2].getReg())
+          .addReg(Cond[3].getReg());
+      break;
     default:
       llvm_unreachable("Invalid branch condition code!");
   }

--- a/test/CodeGen/RISCV/branch.ll
+++ b/test/CodeGen/RISCV/branch.ll
@@ -1,60 +1,122 @@
-; RUN: llc -march=riscv < %s
+; RUN: llc -march=riscv < %s | FileCheck %s
 
 define i32 @eq(i32 %a, i32 %b) {
+; CHECK-LABEL: eq:
   br label %loop
 loop:
   %cond = icmp eq i32 %a, %b
   br i1 %cond, label %loop, label %exit
+; CHECK: beq
   ret i32 1
 exit:
   ret i32 2
 }
 
 define i32 @ne(i32 %a, i32 %b) {
+; CHECK-LABEL: ne:
   br label %loop
 loop:
   %cond = icmp ne i32 %a, %b
   br i1 %cond, label %loop, label %exit
+; CHECK: bne
   ret i32 1
 exit:
   ret i32 2
 }
 
 define i32 @lt(i32 %a, i32 %b) {
+; CHECK-LABEL: lt:
   br label %loop
 loop:
   %cond = icmp slt i32 %a, %b
   br i1 %cond, label %loop, label %exit
+; CHECK: blt
   ret i32 1
 exit:
   ret i32 2
 }
 
 define i32 @ge(i32 %a, i32 %b) {
+; CHECK-LABEL: ge:
   br label %loop
 loop:
   %cond = icmp sge i32 %a, %b
   br i1 %cond, label %loop, label %exit
+; CHECK: bge
   ret i32 1
 exit:
   ret i32 2
 }
 
 define i32 @ltu(i32 %a, i32 %b) {
+; CHECK-LABEL: ltu:
   br label %loop
 loop:
   %cond = icmp ult i32 %a, %b
   br i1 %cond, label %loop, label %exit
+; CHECK: bltu
   ret i32 1
 exit:
   ret i32 2
 }
 
 define i32 @geu(i32 %a, i32 %b) {
+; CHECK-LABEL: geu:
   br label %loop
 loop:
   %cond = icmp uge i32 %a, %b
   br i1 %cond, label %loop, label %exit
+; CHECK: bgeu
+  ret i32 1
+exit:
+  ret i32 2
+}
+
+; Synthesizable branches.
+
+define i32 @gt(i32 %a, i32 %b) {
+; CHECK-LABEL: gt:
+  br label %loop
+loop:
+  %cond = icmp sgt i32 %a, %b
+  br i1 %cond, label %loop, label %exit
+; CHECK: blt
+  ret i32 1
+exit:
+  ret i32 2
+}
+
+define i32 @le(i32 %a, i32 %b) {
+; CHECK-LABEL: le:
+  br label %loop
+loop:
+  %cond = icmp sle i32 %a, %b
+  br i1 %cond, label %loop, label %exit
+; CHECK: bge
+  ret i32 1
+exit:
+  ret i32 2
+}
+
+define i32 @gtu(i32 %a, i32 %b) {
+; CHECK-LABEL: gtu:
+  br label %loop
+loop:
+  %cond = icmp ugt i32 %a, %b
+  br i1 %cond, label %loop, label %exit
+; CHECK: bltu
+  ret i32 1
+exit:
+  ret i32 2
+}
+
+define i32 @leu(i32 %a, i32 %b) {
+; CHECK-LABEL: leu:
+  br label %loop
+loop:
+  %cond = icmp ule i32 %a, %b
+  br i1 %cond, label %loop, label %exit
+; CHECK: bgeu
   ret i32 1
 exit:
   ret i32 2


### PR DESCRIPTION
While testing the rebased riscv-llvm I noticed that some tests were failing with an "Invalid branch condition code!" assertion. This fixes these failures and adds tests for the synthesizable branches.

The code on the default RISCV branch has the same issue. The code on the hwacha branch already has a similar fix.
