### PR TITLE
Add 64-bit CSRs

### DIFF
--- a/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
+++ b/lib/Target/RISCV/AsmParser/RISCVAsmParser.cpp
@@ -33,6 +33,7 @@ public:
   enum RegisterKind {
     PCReg,
     PCRReg,
+    PCR64Reg,
     GR32Reg,
     GR64Reg,
     PairGR64Reg,
@@ -199,6 +200,7 @@ public:
   // Used by the TableGen code to check for particular operand types.
   bool isPCReg() const { return isReg(PCReg); }
   bool isPCRReg() const { return isReg(PCRReg); }
+  bool isPCR64Reg() const { return isReg(PCR64Reg); }
   bool isGR32() const { return isReg(GR32Reg); }
   bool isGR64() const { return isReg(GR64Reg); }
   bool isPairGR64() const { return isReg(PairGR64Reg); }
@@ -282,6 +284,15 @@ static const unsigned PCRRegs[] = {
   RISCV::badvaddr, RISCV::cause, RISCV::hartid, RISCV::impl, 
   //write only
   RISCV::fatc,  RISCV::send_ipi, RISCV::clear_ipi
+};
+
+static const unsigned PCR64Regs[] = {
+  RISCV::status_64, RISCV::epc_64, RISCV::evec_64, RISCV::ptbr_64, RISCV::asid_64,
+  RISCV::count_64, RISCV::compare_64, RISCV::sup0_64, RISCV::sup1_64, RISCV::tohost_64, RISCV::fromhost_64,
+  //read only
+  RISCV::badvaddr_64, RISCV::cause_64, RISCV::hartid_64, RISCV::impl_64, 
+  //write only
+  RISCV::fatc_64,  RISCV::send_ipi_64, RISCV::clear_ipi_64
 };
 
 class RISCVAsmParser : public MCTargetAsmParser {
@@ -453,6 +464,75 @@ public:
     }
     //fallback
     return parseRegister(Operands, 'p', PCRRegs, RISCVOperand::PCRReg);
+  }
+
+  OperandMatchResultTy
+  parsePCR64Reg(SmallVectorImpl<MCParsedAsmOperand*> &Operands) {
+    const AsmToken &Tok = Parser.getTok();
+    if(Tok.is(AsmToken::Identifier) && Tok.getIdentifier().equals("ASM_CR")) {
+      SMLoc S = Tok.getLoc();
+      const AsmToken Tok = Parser.getTok();
+      if(Tok.is(AsmToken::LParen)) {
+        const AsmToken Tok = Parser.getTok();
+        if(Tok.is(AsmToken::Identifier)) {
+          RISCVOperand *op;
+          //TODO: make this a tablegen or something
+          if(Tok.getIdentifier().equals_lower("PCR_K0"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::sup0_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_K1"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::sup1_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_EPC"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::epc_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_badvaddr"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::badvaddr_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_ptbr"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::ptbr_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_ptbr"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::ptbr_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_asid"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::asid_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_count"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::count_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_compare"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::compare_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_evec"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::evec_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_cause"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::cause_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_status"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::status_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_hartid"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::hartid_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_impl"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::impl_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_fatc"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::fatc_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_send_ipi"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::send_ipi_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_clear_ipi"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::clear_ipi_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_tohost"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::tohost_64,S, Tok.getLoc());
+          else if(Tok.getIdentifier().equals_lower("PCR_fromhost"))
+            op = RISCVOperand::createReg(RISCVOperand::PCR64Reg,RISCV::fromhost_64,S, Tok.getLoc());
+          else
+            return MatchOperand_ParseFail;
+
+          Operands.push_back(op);
+
+          Parser.Lex();//eat close paren
+          return MatchOperand_Success;
+        }else {
+          return MatchOperand_ParseFail;
+        }
+      }else {
+        return MatchOperand_ParseFail;
+      }
+    }else {
+      return MatchOperand_NoMatch;
+    }
+    //fallback
+    return parseRegister(Operands, 'p', PCR64Regs, RISCVOperand::PCR64Reg);
   }
 
 };

--- a/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -66,11 +66,13 @@ RISCVTargetLowering::RISCVTargetLowering(RISCVTargetMachine &tm)
 
 
   // Set up special registers.
-  setExceptionPointerRegister(RISCV::epc);
-  setExceptionSelectorRegister(RISCV::evec);
   if(Subtarget.isRV64()) {
+    setExceptionPointerRegister(RISCV::epc_64);
+    setExceptionSelectorRegister(RISCV::evec_64);
     setStackPointerRegisterToSaveRestore(RISCV::sp_64);
   }else {
+    setExceptionPointerRegister(RISCV::epc);
+    setExceptionSelectorRegister(RISCV::evec);
     setStackPointerRegisterToSaveRestore(RISCV::sp);
   }
 

--- a/lib/Target/RISCV/RISCVRegisterInfo.td
+++ b/lib/Target/RISCV/RISCVRegisterInfo.td
@@ -415,6 +415,71 @@ defm PCRReg : RISCVRegClass<"PCRReg", i32, 32, (add
   //write only
   fatc,  send_ipi, clear_ipi), 0>;
 
+class PCR64<bits<16> num, string n> : RISCVReg<n> {
+  let HWEncoding = num;
+}
+//Scratch register for exception handlers
+def sup0_64     : PCR64<0,"cr0">;
+//Scratch register for exception handlers
+def sup1_64     : PCR64<1,"cr1">;
+//exception program counter
+def epc_64      : PCR64<2, "cr2">;
+//Bad virtual address
+def badvaddr_64 : PCR64<3, "cr3">;
+//Page table base register
+def ptbr_64     : PCR64<4, "cr4">;
+//Address space ID
+def asid_64     : PCR64<5, "cr5">;
+//Cycle counter for timer
+def count_64    : PCR64<6, "cr6">;
+//Timer compare value
+def compare_64  : PCR64<7, "cr7">;
+//Exception handler address
+def evec_64     : PCR64<8, "cr8">;
+//Cause of exception
+def cause_64    : PCR64<9, "cr9">;
+//status reg
+def status_64   : PCR64<10, "cr10">;
+//Hart ID
+def hartid_64   : PCR64<11,"cr11">;
+//Implementation ID
+def impl_64     : PCR64<12,"cr12">;
+//Flush address translation cache
+def fatc_64     : PCR64<13, "cr13">;
+//Send inter-processor interrupt
+def send_ipi_64 : PCR64<14,"cr14">;
+//Clear inter-processor interrupt
+def clear_ipi_64: PCR64<15,"cr15">;
+//Reserved 
+def pr0_64      : PCR64<16,"cr16">;
+def pr1_64      : PCR64<17,"cr17">;
+def pr2_64      : PCR64<18,"cr18">;
+def pr3_64      : PCR64<19,"cr19">;
+def pr4_64      : PCR64<20,"cr20">;
+def pr5_64      : PCR64<21,"cr21">;
+def pr6_64      : PCR64<22,"cr22">;
+def pr7_64      : PCR64<23,"cr23">;
+def pr8_64      : PCR64<24,"cr24">;
+def pr9_64      : PCR64<25,"cr25">;
+def pr10_64     : PCR64<26,"cr26">;
+def pr11_64     : PCR64<27,"cr27">;
+def pr12_64     : PCR64<28,"cr28">;
+def pr13_64     : PCR64<29,"cr29">;
+//Test output register
+def tohost_64   : PCR64<30,"cr30">;
+//Test input register
+def fromhost_64 : PCR64<31,"cr31">;
+
+//PCRs (64-bit)
+defm PCR64Reg : RISCVRegClass<"PCR64Reg", i64, 64, (add
+  //read/write
+  status_64, epc_64, evec_64, ptbr_64, asid_64, count_64, compare_64, 
+  sup0_64, sup1_64, tohost_64, fromhost_64,
+  //read only
+  badvaddr_64, cause_64, hartid_64, impl_64, 
+  //write only
+  fatc_64,  send_ipi_64, clear_ipi_64), 0>;
+
 
 //===----------------------------------------------------------------------===//
 // Other registers


### PR DESCRIPTION
Add 64-bit version of the CSRs. This makes compiling with C++ exceptions get a bit further. I may also try to add CSRR so it actually works but will post another pull request if so.
