### PR TITLE
Fix use init array

### DIFF
--- a/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
+++ b/lib/Target/RISCV/MCTargetDesc/RISCVMCAsmInfo.cpp
@@ -29,6 +29,7 @@ RISCVMCAsmInfo::RISCVMCAsmInfo(const Target &T, StringRef TT) {
   SupportsDebugInformation = true;
   HasLEB128 = true;
   ExceptionsType = ExceptionHandling::DwarfCFI;
+  AlignmentIsInBytes = false;
 }
 
 const MCSection *

--- a/lib/Target/RISCV/RISCVISelLowering.cpp
+++ b/lib/Target/RISCV/RISCVISelLowering.cpp
@@ -48,12 +48,16 @@ static const uint16_t FPDRegs[8] = {
   RISCV::fa4_64, RISCV::fa5_64, RISCV::fa6_64, RISCV::fa7_64
 };
 
+void RISCVTargetObjectFile::Initialize(MCContext &Ctx, const TargetMachine &TM) {
+  TargetLoweringObjectFileELF::Initialize(Ctx, TM);
+  InitializeELF(TM.Options.UseInitArray);
+}
+
 RISCVTargetLowering::RISCVTargetLowering(RISCVTargetMachine &tm)
-  : TargetLowering(tm, new TargetLoweringObjectFileELF()),
+  : TargetLowering(tm, new RISCVTargetObjectFile()),
     Subtarget(*tm.getSubtargetImpl()), TM(tm), 
     IsRV32(Subtarget.isRV32()) {
   MVT PtrVT = getPointerTy();
-
   // Set up the register classes.
   addRegisterClass(MVT::i32,  &RISCV::GR32BitRegClass);
   if(Subtarget.isRV64())

--- a/lib/Target/RISCV/RISCVISelLowering.h
+++ b/lib/Target/RISCV/RISCVISelLowering.h
@@ -21,6 +21,7 @@
 #include "llvm/CodeGen/SelectionDAG.h"
 #include "llvm/IR/Function.h"
 #include "llvm/Target/TargetLowering.h"
+#include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 #include <string>
 #include <deque>
 
@@ -315,6 +316,11 @@ private:
   void writeVarArgRegs(std::vector<SDValue> &OutChains, const RISCVCC &CC,
                        SDValue Chain, DebugLoc DL, SelectionDAG &DAG) const;
 };
+
+class RISCVTargetObjectFile : public TargetLoweringObjectFileELF {
+  void Initialize(MCContext &Ctx, const TargetMachine &TM);
+};
+
 } // end namespace llvm
 
 #endif // LLVM_TARGET_RISCV_ISELLOWERING_H


### PR DESCRIPTION
Fixes a couple of bugs that prevent -use-init-array (and hence C++ with global initialisers, e.g. iostreams) working on RISCV.
