### PR TITLE
RISCV: Implement CSRR and CSRW

### DIFF
--- a/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -454,6 +454,30 @@ RISCVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     BuildMI(MBB, MBBI, DL, get(Opcode), DestReg)
       .addReg(SrcReg, getKillRegState(KillSrc));
     return;
+  }else if(RISCV::PCR64RegBitRegClass.contains(SrcReg) &&
+           RISCV::GR64BitRegClass.contains(DestReg)) {
+    Opcode = RISCV::CSRR_64;
+    BuildMI(MBB, MBBI, DL, get(Opcode), DestReg)
+      .addReg(SrcReg, getKillRegState(KillSrc));
+    return;
+  }else if(RISCV::PCR64RegBitRegClass.contains(DestReg) &&
+           RISCV::GR64BitRegClass.contains(SrcReg)) {
+    Opcode = RISCV::CSRW_64;
+    BuildMI(MBB, MBBI, DL, get(Opcode), DestReg)
+      .addReg(SrcReg, getKillRegState(KillSrc));
+    return;
+  }else if(RISCV::PCRRegBitRegClass.contains(SrcReg) &&
+           RISCV::GR32BitRegClass.contains(DestReg)) {
+    Opcode = RISCV::CSRR;
+    BuildMI(MBB, MBBI, DL, get(Opcode), DestReg)
+      .addReg(SrcReg, getKillRegState(KillSrc));
+    return;
+  }else if(RISCV::PCRRegBitRegClass.contains(DestReg) &&
+           RISCV::GR32BitRegClass.contains(SrcReg)) {
+    Opcode = RISCV::CSRW;
+    BuildMI(MBB, MBBI, DL, get(Opcode), DestReg)
+      .addReg(SrcReg, getKillRegState(KillSrc));
+    return;  
   }else
     llvm_unreachable("Impossible reg-to-reg copy");
 

--- a/lib/Target/RISCV/RISCVInstrInfo.td
+++ b/lib/Target/RISCV/RISCVInstrInfo.td
@@ -340,6 +340,46 @@ def FENCE: InstRISCV<4, (outs), (ins fenceImm:$pred, fenceImm:$succ), "fence",
       }
 
 //===----------------------------------------------------------------------===//
+// CSR access (some of the regs are available in user mode)
+//===----------------------------------------------------------------------===//
+
+// We only need CSRR and CSRW for exception handling etc.
+// The others are generally complicated atomic operations.
+// Supporting them would require adding more intrinsics.
+
+def CSRR: InstRISCV<4, (outs GR32:$dst), (ins PCRReg:$csr),
+              "csrr\t$dst, $csr",
+              [(set GR32:$dst, PCRReg:$csr)]>,Requires<[IsRV32]> {
+  field bits<32> Inst;
+  
+  bits<12> CSR;
+  bits<5> RD;
+
+  // Encoded as CSRRS rd, csr, z0
+  let Inst{31-20} = CSR;
+  let Inst{19-15} = 0;
+  let Inst{14-12} = 0b010;
+  let Inst{11-7} = RD;
+  let Inst{6-0} = 0b1110011;
+}
+
+def CSRW: InstRISCV<4, (outs PCRReg:$csr), (ins GR32:$src),
+              "csrw\t$csr, $src",
+              [(set PCRReg:$csr, GR32:$src)]>,Requires<[IsRV32]> {
+  field bits<32> Inst;
+  
+  bits<12> CSR;
+  bits<5> RS1;
+
+  // Encoded as CSRRW z0, csr, rs1
+  let Inst{31-20} = CSR;
+  let Inst{19-15} = RS1;
+  let Inst{14-12} = 0b001;
+  let Inst{11-7} = 0;
+  let Inst{6-0} = 0b1110011;
+}
+
+//===----------------------------------------------------------------------===//
 // Subtarget features
 //===----------------------------------------------------------------------===//
 

--- a/lib/Target/RISCV/RISCVInstrInfoRV64.td
+++ b/lib/Target/RISCV/RISCVInstrInfoRV64.td
@@ -360,3 +360,44 @@ let isReturn = 1, isTerminator = 1, isBarrier = 1, hasCtrlDep = 1,
           }
    }
   def : Pat<(r_retflag), (RET)>, Requires<[IsRV64]>;
+
+//===----------------------------------------------------------------------===//
+// 64-bit CSR access (some of the regs are available in user mode)
+//===----------------------------------------------------------------------===//
+
+// We only need CSRR and CSRW for exception handling etc.
+// The others are generally complicated atomic operations.
+// Supporting them would require adding more intrinsics.
+
+def CSRR_64: InstRISCV<4, (outs GR64:$dst), (ins PCR64Reg:$csr),
+              "csrr\t$dst, $csr",
+              [(set GR64:$dst, PCR64Reg:$csr)]>,Requires<[IsRV64]> {
+  field bits<32> Inst;
+  
+  bits<12> CSR;
+  bits<5> RD;
+
+  // Encoded as CSRRS rd, csr, z0
+  let Inst{31-20} = CSR;
+  let Inst{19-15} = 0;
+  let Inst{14-12} = 0b010;
+  let Inst{11-7} = RD;
+  let Inst{6-0} = 0b1110011;
+}
+
+def CSRW_64: InstRISCV<4, (outs PCR64Reg:$csr), (ins GR64:$src),
+              "csrw\t$csr, $src",
+              [(set PCR64Reg:$csr, GR64:$src)]>,Requires<[IsRV64]> {
+  field bits<32> Inst;
+  
+  bits<12> CSR;
+  bits<5> RS1;
+
+  // Encoded as CSRRW z0, csr, rs1
+  let Inst{31-20} = CSR;
+  let Inst{19-15} = RS1;
+  let Inst{14-12} = 0b001;
+  let Inst{11-7} = 0;
+  let Inst{6-0} = 0b1110011;
+}
+


### PR DESCRIPTION
Note that this still doesn't make exception handling work because 1) the CSR names are out of date and 2) userspace exception handling isn't really supported upstream yet. But it's a step forward and I need it to set CSRs for tagged registers. Also, there are user-mode CSRs, notably cycle counters, so we will need this eventually.
