### PR TITLE
riscv: InsertBranch must insert 2-way jumps <-> TBB && FBB

### DIFF
--- a/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -204,7 +204,7 @@ RISCVInstrInfo::InsertBranch(MachineBasicBlock &MBB, MachineBasicBlock *TBB,
                                const SmallVectorImpl<MachineOperand> &Cond,
                                DebugLoc DL) const {
   //RISCV doesn't have any two way branches, can only have FBB if it is a fall through
-  if (FBB && !MBB.isLayoutSuccessor(FBB)) {
+  if (FBB) {
     //Need to build two branches then
     //one to branch to TBB on Cond
     //and a second one immediately after to unconditionally jump to FBB


### PR DESCRIPTION
The InsertBranch utility function is not allowed to rely on the current MBB
layout. Therefore unconditional jumps have to be inserted if FBB!=nullptr.

Should Fix #16 
