### PR TITLE
Correct Hello World example directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use
 --------------------------------------------------------------------
 
 Using the llvm-riscv is fairly simple to build a full executable however you
-need riscv-64-unknown-\*-gcc to do the assembling and linking. An example of compiling hello
+need riscv64-unknown-\*-gcc to do the assembling and linking. An example of compiling hello
 world:
 
 	$ cat hello.c
@@ -86,6 +86,6 @@ world:
 	int main() {
 	    printf("Hello World!\n");
 	}
-	$ clang -target riscv -mriscv=RV64IAMFD -S hello.c -o hello.S
-	$ riscv-64-unknown-elf-gcc -o hello.riscv hello.S
+	$ clang -target riscv64 -mriscv=RV64IAMFD -S hello.c -o hello.S
+	$ riscv64-unknown-elf-gcc -o hello.riscv hello.S
 


### PR DESCRIPTION
The existing directions seem to have a couple of issues:
- Using `-target riscv` (as opposed to `riscv64`) with clang results in an error described as: `fatal error: error in backend: Cannot select: t2: i32 = GlobalAddress<[14 x i8]* @.str> 0`.
- `riscv64-unknown-elf-gcc` has an extra `-` in it.

I've tried the suggested modifications, which do seem to work with a recent build of the RISC-V toolchains.
