### PR TITLE
adding CMake build details to top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,20 @@ Installation
 ------------------------------------------------------------------
 
 The LLVM RISCV backend is built just as the normal LLVM system.
+You may utilize autotools or CMake
 
 	$ git clone -b RISCV https://github.com/riscv/riscv-llvm.git
 	$ git submodule update --init
 	$ mkdir build
 	$ cd build
+    - Autotools
 	$ ../configure --prefix=/opt/riscv --enable-targets=riscv
 	$ make
 	$ make install
+    - CMake
+        $ cmake -DCMAKE_INSTALL_PREFIX=/opt/riscv -DLLVM_TARGETS_TO_BUILD="RISCV" ../
+        $ make
+        $ make install
 
 Now if `/opt/riscv` is on your path you should be able to use clang and LLVM with
 RISC-V support.

--- a/lib/Target/RISCV/RISCVInstrInfoA.td
+++ b/lib/Target/RISCV/RISCVInstrInfoA.td
@@ -1,4 +1,4 @@
-//===- RISCVInstrInfoA.td - Floating-point RISCV instructions -*- tblgen-*-===//
+//===- RISCVInstrInfoA.td - Atomic RISCV instructions -*- tblgen-*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //

--- a/lib/Target/RISCV/RISCVInstrInfoD.td
+++ b/lib/Target/RISCV/RISCVInstrInfoD.td
@@ -1,4 +1,4 @@
-//===- RISCVInstrFP.td - Floating-point RISCV instructions ----*- tblgen-*-===//
+//===- RISCVInstrInfoD.td - DP Floating-Point RISCV instructions ----*- tblgen-*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //

--- a/lib/Target/RISCV/RISCVInstrInfoF.td
+++ b/lib/Target/RISCV/RISCVInstrInfoF.td
@@ -1,4 +1,4 @@
-//===- RISCVInstrFP.td - Floating-point RISCV instructions ----*- tblgen-*-===//
+//===- RISCVInstrInfoF.td - Floating-point RISCV instructions ----*- tblgen-*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //

--- a/lib/Target/RISCV/RISCVInstrInfoM.td
+++ b/lib/Target/RISCV/RISCVInstrInfoM.td
@@ -1,4 +1,4 @@
-//===- RISCVInstrM.td - Multiply Divide RISCV instructions ----*- tblgen-*-===//
+//===- RISCVInstrInfoM.td - Multiply Divide RISCV instructions ----*- tblgen-*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //

--- a/lib/Target/RISCV/RISCVInstrInfoRV64.td
+++ b/lib/Target/RISCV/RISCVInstrInfoRV64.td
@@ -1,4 +1,4 @@
-//===- RISCVInstrRV64.td - RISCV RV64I instructions -----------*- tblgen-*-===//
+//===- RISCVInstrInfoRV64.td - RISCV RV64I instructions -----------*- tblgen-*-===//
 //
 //                     The LLVM Compiler Infrastructure
 //


### PR DESCRIPTION
Given that autotools is quickly becoming deprecated in LLVM, I added the sample build directives to the README
