### PR TITLE
Fix LLVMInitializeRISCVTargetMC

### DIFF
--- a/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
+++ b/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.cpp
@@ -140,7 +140,7 @@ extern "C" void LLVMInitializeRISCVTargetMC() {
   // Register the MCInstrInfo.
   TargetRegistry::RegisterMCInstrInfo(TheRISCVTarget,
                                       createRISCVMCInstrInfo);
-  TargetRegistry::RegisterMCInstrInfo(TheRISCVTarget,
+  TargetRegistry::RegisterMCInstrInfo(TheRISCV64Target,
                                       createRISCVMCInstrInfo);
 
   // Register the MCRegisterInfo.


### PR DESCRIPTION
Only register the MCInstrInfo for riscv once and actually register it for riscv64.
