### PR TITLE
Fix link error and clang warnings

### DIFF
--- a/lib/Target/RISCV/LLVMBuild.txt
+++ b/lib/Target/RISCV/LLVMBuild.txt
@@ -30,5 +30,5 @@ has_jit = 1
 type = Library
 name = RISCVCodeGen
 parent = RISCV
-required_libraries = AsmPrinter CodeGen Core MC SelectionDAG RISCVDesc RISCVInfo Support Target
+required_libraries = AsmPrinter CodeGen Core MC SelectionDAG RISCVAsmPrinter RISCVDesc RISCVInfo Support Target
 add_to_library_groups = RISCV

--- a/lib/Target/RISCV/RISCVFrameLowering.h
+++ b/lib/Target/RISCV/RISCVFrameLowering.h
@@ -20,12 +20,12 @@ class RISCVFrameLowering : public TargetFrameLowering {
 public:
   RISCVFrameLowering();
 
-  bool hasFP(const MachineFunction &MF) const;
+  bool hasFP(const MachineFunction &MF) const override;
 
   /// emitProlog/emitEpilog - These methods insert prolog and epilog code into
   /// the function.
-  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
-  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
+  void emitPrologue(MachineFunction&, MachineBasicBlock&) const override;
+  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const override;
 
   MachineBasicBlock::iterator
   eliminateCallFramePseudoInstr(MachineFunction &MF,
@@ -35,9 +35,9 @@ public:
   bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
                                  MachineBasicBlock::iterator MI,
                                  const std::vector<CalleeSavedInfo> &CSI,
-                                 const TargetRegisterInfo *TRI) const;
+                                 const TargetRegisterInfo *TRI) const override;
 
-  bool hasReservedCallFrame(const MachineFunction &MF) const;
+  bool hasReservedCallFrame(const MachineFunction &MF) const override;
 
   void determineCalleeSaves(MachineFunction &MF, BitVector &SavedRegs,
                                             RegScavenger *RS) const override;

--- a/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
+++ b/lib/Target/RISCV/RISCVISelDAGToDAG.cpp
@@ -213,7 +213,7 @@ public:
   }
 
   // Override SelectionDAGISel.
-  virtual bool runOnMachineFunction(MachineFunction &MF);
+  bool runOnMachineFunction(MachineFunction &MF) override;
   void Select(SDNode *Node) override;
   virtual void processFunctionAfterISel(MachineFunction &MF);
   bool SelectInlineAsmMemoryOperand(const SDValue &Op, unsigned ConstraintID,

--- a/lib/Target/RISCV/RISCVISelLowering.h
+++ b/lib/Target/RISCV/RISCVISelLowering.h
@@ -120,7 +120,7 @@ public:
   unsigned
   getExceptionSelectorRegister(const Constant *PersonalityFn) const override;
 
-  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
+  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const override;
   bool isFPImmLegal(const APFloat &Imm, EVT VT) const override;
   const char *getTargetNodeName(unsigned Opcode) const override;
   std::pair<unsigned, const TargetRegisterClass *>
@@ -153,7 +153,7 @@ public:
     CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
                    bool isVarArg,
                    const SmallVectorImpl<ISD::OutputArg> &Outs,
-                   LLVMContext &Context) const;
+                   LLVMContext &Context) const override;
 
   SDValue LowerReturn(SDValue Chain, CallingConv::ID CallConv, bool IsVarArg,
                       const SmallVectorImpl<ISD::OutputArg> &Outs,

--- a/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -217,8 +217,6 @@ unsigned
 RISCVInstrInfo::InsertConstBranchAtInst(MachineBasicBlock &MBB, MachineInstr *I, int64_t offset,
                                ArrayRef<MachineOperand> Cond,
                                const DebugLoc &DL) const {
-  // Shouldn't be a fall through.
-  assert(&MBB && "InsertBranch must not be told to insert a fallthrough");
   assert(Cond.size() <= 4 &&
          "RISCV branch conditions have less than four components!");
 


### PR DESCRIPTION
```
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVMachineFunctionInfo.cpp.o
In file included from ../lib/Target/RISCV/RISCVMachineFunctionInfo.cpp:13:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVMachineFunctionInfo.cpp:13:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVMachineFunctionInfo.cpp:13:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVMachineFunctionInfo.cpp:13:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVMachineFunctionInfo.cpp:13:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVMachineFunctionInfo.cpp:13:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVMachineFunctionInfo.cpp:13:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
7 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVSubtarget.cpp.o
In file included from ../lib/Target/RISCV/RISCVSubtarget.cpp:10:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVSubtarget.cpp:10:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVSubtarget.cpp:10:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVSubtarget.cpp:10:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVSubtarget.cpp:10:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVSubtarget.cpp:10:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVSubtarget.cpp:10:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
7 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVMCInstLower.cpp.o
In file included from ../lib/Target/RISCV/RISCVMCInstLower.cpp:11:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVMCInstLower.cpp:11:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVMCInstLower.cpp:11:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVMCInstLower.cpp:11:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVMCInstLower.cpp:11:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVMCInstLower.cpp:11:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVMCInstLower.cpp:11:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
7 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVInstrInfo.cpp.o
In file included from ../lib/Target/RISCV/RISCVInstrInfo.cpp:16:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVInstrInfo.cpp:16:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVInstrInfo.cpp:16:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVInstrInfo.cpp:16:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVInstrInfo.cpp:16:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVInstrInfo.cpp:16:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVInstrInfo.cpp:16:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
../lib/Target/RISCV/RISCVInstrInfo.cpp:221:11: warning: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]
  assert(&MBB && "InsertBranch must not be told to insert a fallthrough");
          ^~~ ~~
/usr/include/assert.h:89:5: note: expanded from macro 'assert'
  ((expr)                                                               \
    ^~~~
8 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVISelDAGToDAG.cpp.o
In file included from ../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:14:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:14:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:14:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:14:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:14:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:14:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:14:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:216:16: warning: 'runOnMachineFunction' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  virtual bool runOnMachineFunction(MachineFunction &MF);
               ^
../include/llvm/CodeGen/SelectionDAGISel.h:67:8: note: overridden virtual function is here
  bool runOnMachineFunction(MachineFunction &MF) override;
       ^
../lib/Target/RISCV/RISCVISelDAGToDAG.cpp:458:16: warning: unused variable 'I' [-Wunused-variable]
    for (auto &I: MBB) {
               ^
9 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVAsmPrinter.cpp.o
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.cpp:15:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.cpp:15:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.cpp:15:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.cpp:15:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.cpp:15:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.cpp:15:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.cpp:15:
In file included from ../lib/Target/RISCV/RISCVAsmPrinter.h:13:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
7 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVRegisterInfo.cpp.o
In file included from ../lib/Target/RISCV/RISCVRegisterInfo.cpp:11:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVRegisterInfo.cpp:11:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVRegisterInfo.cpp:11:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVRegisterInfo.cpp:11:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVRegisterInfo.cpp:11:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVRegisterInfo.cpp:11:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVRegisterInfo.cpp:11:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
7 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVFrameLowering.cpp.o
In file included from ../lib/Target/RISCV/RISCVFrameLowering.cpp:10:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVFrameLowering.cpp:10:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVFrameLowering.cpp:10:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVFrameLowering.cpp:10:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVFrameLowering.cpp:10:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVFrameLowering.cpp:15:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVFrameLowering.cpp:15:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
7 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVTargetMachine.cpp.o
In file included from ../lib/Target/RISCV/RISCVTargetMachine.cpp:10:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVTargetMachine.cpp:10:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVTargetMachine.cpp:10:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVTargetMachine.cpp:10:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVTargetMachine.cpp:10:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
In file included from ../lib/Target/RISCV/RISCVTargetMachine.cpp:10:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVTargetMachine.cpp:10:
In file included from ../lib/Target/RISCV/RISCVTargetMachine.h:18:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:18:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
7 warnings generated.
[1087/1136] Building CXX object lib/Target/RISCV/CMakeFiles/LLVMRISCVCodeGen.dir/RISCVISelLowering.cpp.o
In file included from ../lib/Target/RISCV/RISCVISelLowering.cpp:16:
../lib/Target/RISCV/RISCVISelLowering.h:123:8: warning: 'isOffsetFoldingLegal' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
       ^
../include/llvm/Target/TargetLowering.h:2222:16: note: overridden virtual function is here
  virtual bool isOffsetFoldingLegal(const GlobalAddressSDNode *GA) const;
               ^
In file included from ../lib/Target/RISCV/RISCVISelLowering.cpp:16:
../lib/Target/RISCV/RISCVISelLowering.h:153:5: warning: 'CanLowerReturn' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    CanLowerReturn(CallingConv::ID CallConv, MachineFunction &MF,
    ^
../include/llvm/Target/TargetLowering.h:2644:16: note: overridden virtual function is here
  virtual bool CanLowerReturn(CallingConv::ID /*CallConv*/,
               ^
In file included from ../lib/Target/RISCV/RISCVISelLowering.cpp:20:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:23:8: warning: 'hasFP' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasFP(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:216:16: note: overridden virtual function is here
  virtual bool hasFP(const MachineFunction &MF) const = 0;
               ^
In file included from ../lib/Target/RISCV/RISCVISelLowering.cpp:20:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:27:8: warning: 'emitPrologue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitPrologue(MachineFunction&, MachineBasicBlock&) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:163:16: note: overridden virtual function is here
  virtual void emitPrologue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVISelLowering.cpp:20:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:28:8: warning: 'emitEpilogue' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  void emitEpilogue(MachineFunction &MF, MachineBasicBlock &MBB) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:165:16: note: overridden virtual function is here
  virtual void emitEpilogue(MachineFunction &MF,
               ^
In file included from ../lib/Target/RISCV/RISCVISelLowering.cpp:20:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:35:8: warning: 'spillCalleeSavedRegisters' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
       ^
../include/llvm/Target/TargetFrameLowering.h:192:16: note: overridden virtual function is here
  virtual bool spillCalleeSavedRegisters(MachineBasicBlock &MBB,
               ^
In file included from ../lib/Target/RISCV/RISCVISelLowering.cpp:20:
In file included from ../lib/Target/RISCV/RISCVSubtarget.h:17:
../lib/Target/RISCV/RISCVFrameLowering.h:40:8: warning: 'hasReservedCallFrame' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  bool hasReservedCallFrame(const MachineFunction &MF) const;
       ^
../include/llvm/Target/TargetFrameLowering.h:223:16: note: overridden virtual function is here
  virtual bool hasReservedCallFrame(const MachineFunction &MF) const {
               ^
../lib/Target/RISCV/RISCVISelLowering.cpp:42:24: warning: unused variable 'FPFRegs' [-Wunused-const-variable]
static const MCPhysReg FPFRegs[8] = {
                       ^
../lib/Target/RISCV/RISCVISelLowering.cpp:47:24: warning: unused variable 'FPDRegs' [-Wunused-const-variable]
static const MCPhysReg FPDRegs[8] = {
                       ^
9 warnings generated.
```
