### PR TITLE
Fix link error of RISCVAsmPrinter

### DIFF
--- a/lib/Target/RISCV/LLVMBuild.txt
+++ b/lib/Target/RISCV/LLVMBuild.txt
@@ -30,5 +30,5 @@ has_jit = 1
 type = Library
 name = RISCVCodeGen
 parent = RISCV
-required_libraries = AsmPrinter CodeGen Core MC SelectionDAG RISCVDesc RISCVInfo Support Target
+required_libraries = AsmPrinter CodeGen Core MC SelectionDAG RISCVAsmPrinter RISCVDesc RISCVInfo Support Target
 add_to_library_groups = RISCV


### PR DESCRIPTION
When building LLVM with shared libraries on, the linking process for
LLVMRISCVCodeGen fails, as it requires LLVMRISCVAsmPrinter.

This was already proposed in #35. However, it was not merged.